### PR TITLE
Fix issue with Exit popups without saving state-BCMOHAD-22017

### DIFF
--- a/frontend/app/src/components/base/BaseAddRecord.vue
+++ b/frontend/app/src/components/base/BaseAddRecord.vue
@@ -14,7 +14,7 @@ export default {
       default: () => [],
     },
   },
-  emits: ['handle-record-add'],
+  emits: ['handle-record-add', 'cancel-filter-data'],
   data() {
     return {
       loading: this.isLoading,
@@ -25,6 +25,10 @@ export default {
   methods: {
     handleSave() {
       this.$emit('handle-record-add', this.selectedItemToAdd);
+    },
+    cancelFilterData() {
+      // (this.selectedData = this.preselectedData),
+      this.$emit('cancel-filter-data');
     },
   },
 };
@@ -44,20 +48,27 @@ export default {
           :label="index"
         ></v-text-field>
       </v-col>
-      <v-card-actions class="justify-center">
-        <v-btn
-          :disabled="loading"
-          :loading="loading"
-          block
-          class="text-none mb-4 text-primary"
-          color="indigo-darken-3"
-          size="x-large"
-          variant="outlined"
-          @click="handleSave"
-        >
-          Save
-        </v-btn>
-      </v-card-actions>
+      <v-btn
+        :disabled="loading"
+        :loading="loading"
+        block
+        class="text-none mb-4 text-primary"
+        color="indigo-darken-3"
+        size="x-large"
+        variant="outlined"
+        @click="handleSave"
+      >
+        Save
+      </v-btn>
+      <v-btn
+        data-test="cancel-btn"
+        class="mt-3 text-primary"
+        size="x-large"
+        block
+        variant="outlined"
+        @click="cancelFilterData"
+        >Cancel</v-btn
+      >
     </v-card-text>
   </v-card>
 </template>

--- a/frontend/app/src/components/base/BaseAddStatus.vue
+++ b/frontend/app/src/components/base/BaseAddStatus.vue
@@ -14,7 +14,7 @@ export default {
       default: () => [],
     },
   },
-  emits: ['handle-record-add'],
+  emits: ['handle-record-add', 'cancel-filter-data'],
   data() {
     return {
       loading: this.isLoading,
@@ -25,6 +25,10 @@ export default {
   methods: {
     handleSave() {
       this.$emit('handle-record-add', this.selectedItemToAdd);
+    },
+    cancelFilterData() {
+      // (this.selectedData = this.preselectedData),
+      this.$emit('cancel-filter-data');
     },
   },
 };
@@ -44,7 +48,6 @@ export default {
           density="compact"
           solid
           variant="outlined"
-          class="mr-2 pl-2"
         ></v-select>
         <v-text-field
           v-if="index !== 'type'"
@@ -55,20 +58,25 @@ export default {
           :label="index"
         ></v-text-field>
       </v-col>
-      <v-card-actions class="justify-center">
-        <v-btn
-          :disabled="loading"
-          :loading="loading"
-          block
-          class="text-none mb-4 text-primary"
-          color="indigo-darken-3"
-          size="x-large"
-          variant="outlined"
-          @click="handleSave"
-        >
-          Save
-        </v-btn>
-      </v-card-actions>
+      <v-btn
+        :disabled="loading"
+        :loading="loading"
+        block
+        class="bg-primary"
+        size="x-large"
+        @click="handleSave"
+      >
+        Save
+      </v-btn>
+      <v-btn
+        data-test="cancel-btn"
+        class="mt-3 text-primary"
+        size="x-large"
+        block
+        variant="outlined"
+        @click="cancelFilterData"
+        >Cancel</v-btn
+      >
     </v-card-text>
   </v-card>
 </template>

--- a/frontend/app/src/components/base/BaseEditRecord.vue
+++ b/frontend/app/src/components/base/BaseEditRecord.vue
@@ -14,7 +14,7 @@ export default {
       default: () => [],
     },
   },
-  emits: ['handle-record-save'],
+  emits: ['handle-record-save', 'cancel-filter-data'],
   data() {
     return {
       loading: this.isLoading,
@@ -30,6 +30,10 @@ export default {
           id: this.idToEdit,
         });
       }
+    },
+    cancelFilterData() {
+      // (this.selectedData = this.preselectedData),
+      this.$emit('cancel-filter-data');
     },
     checkForm: function (e) {
       e.preventDefault();
@@ -65,20 +69,25 @@ export default {
             :label="key"
           ></v-text-field>
         </v-col>
-        <v-card-actions class="justify-center">
-          <v-btn
-            :disabled="loading"
-            :loading="loading"
-            block
-            class="text-none mb-4 text-primary"
-            color="indigo-darken-3"
-            size="x-large"
-            variant="outlined"
-            type="submit"
-          >
-            Save
-          </v-btn>
-        </v-card-actions>
+        <v-btn
+          :disabled="loading"
+          :loading="loading"
+          block
+          class="bg-primary"
+          size="x-large"
+          type="submit"
+        >
+          Save
+        </v-btn>
+        <v-btn
+          data-test="cancel-btn"
+          class="mt-3 text-primary"
+          size="x-large"
+          block
+          variant="outlined"
+          @click="cancelFilterData"
+          >Cancel</v-btn
+        >
       </v-form>
     </v-card-text>
   </v-card>

--- a/frontend/app/src/components/base/BaseEditStatus.vue
+++ b/frontend/app/src/components/base/BaseEditStatus.vue
@@ -14,7 +14,7 @@ export default {
       default: () => [],
     },
   },
-  emits: ['handle-record-save'],
+  emits: ['handle-record-save', 'cancel-filter-data'],
   data() {
     return {
       loading: this.isLoading,
@@ -47,6 +47,10 @@ export default {
         });
       }
     },
+    cancelFilterData() {
+      // (this.selectedData = this.preselectedData),
+      this.$emit('cancel-filter-data');
+    },
     checkForm: function (e) {
       e.preventDefault();
     },
@@ -74,7 +78,6 @@ export default {
             density="compact"
             solid
             variant="outlined"
-            class="mr-2 pl-2"
           ></v-select>
           <v-text-field
             v-if="key !== 'type'"
@@ -91,20 +94,25 @@ export default {
             "
           ></v-text-field>
         </v-col>
-        <v-card-actions class="justify-center">
-          <v-btn
-            :disabled="loading"
-            :loading="loading"
-            block
-            class="text-none mb-4 text-primary"
-            color="indigo-darken-3"
-            size="x-large"
-            variant="outlined"
-            type="submit"
-          >
-            Save
-          </v-btn>
-        </v-card-actions>
+        <v-btn
+          :disabled="loading"
+          :loading="loading"
+          block
+          class="bg-primary"
+          size="x-large"
+          type="submit"
+        >
+          Save
+        </v-btn>
+        <v-btn
+          data-test="cancel-btn"
+          class="mt-3 text-primary"
+          size="x-large"
+          block
+          variant="outlined"
+          @click="cancelFilterData"
+          >Cancel</v-btn
+        >
       </v-form>
     </v-card-text>
   </v-card>

--- a/frontend/app/src/components/base/BaseFilter.vue
+++ b/frontend/app/src/components/base/BaseFilter.vue
@@ -134,14 +134,18 @@ export default {
       </v-data-table>
       <v-btn
         data-test="save-btn"
-        class="bg-primary mt-3"
+        block
+        class="bg-primary"
+        size="x-large"
         @click="savingFilterData"
       >
         {{ inputSaveButtonText }}
       </v-btn>
       <v-btn
         data-test="cancel-btn"
-        class="mt-3 ml-3 text-primary"
+        class="mt-3 text-primary"
+        size="x-large"
+        block
         variant="outlined"
         @click="cancelFilterData"
         >Cancel</v-btn

--- a/frontend/app/src/views/setting/ManageStatusCode.vue
+++ b/frontend/app/src/views/setting/ManageStatusCode.vue
@@ -472,6 +472,7 @@ export default {
           :ignore-to-edit="ignoreToEdit"
           :is-loading="loading"
           @handle-record-save="handleRecordSave"
+          @cancel-filter-data="dialog = false"
         />
       </v-dialog>
 
@@ -480,6 +481,7 @@ export default {
           :item-to-add="{ code: '', description: '', type: 'USER' }"
           :is-loading="loading"
           @handle-record-add="handleRecordAdd"
+          @cancel-filter-data="dialogNewItem = false"
         />
       </v-dialog>
     </div>

--- a/frontend/app/src/views/source-data/ProcessControlView.vue
+++ b/frontend/app/src/views/source-data/ProcessControlView.vue
@@ -55,6 +55,7 @@ export default {
       { key: 'statusCode' },
       { key: 'controlTableId' },
       { key: 'rowstatusCode' },
+      { key: 'errorMsg' },
     ],
     headers: [
       {
@@ -564,6 +565,7 @@ export default {
           :ignore-to-edit="ignoreToEdit"
           :is-loading="loading"
           @handle-record-save="handleRecordSave"
+          @cancel-filter-data="dialog = false"
         />
       </v-dialog>
 

--- a/frontend/app/src/views/source-data/SourceControlView.vue
+++ b/frontend/app/src/views/source-data/SourceControlView.vue
@@ -395,6 +395,7 @@ export default {
           :ignore-to-edit="ignoreToEdit"
           :is-loading="loading"
           @handle-record-save="handleRecordSave"
+          @cancel-filter-data="dialog = false"
         />
       </v-dialog>
     </div>


### PR DESCRIPTION
There were some Popups without the close button so the user was forcefully saving the data. Now every Popup have close button so that a user can close the popup if he wish to close the popup without saving data.