### PR TITLE
Remove all the CRUD operations from Status screen

### DIFF
--- a/frontend/app/src/components/bcgov/BCGovNavBar.vue
+++ b/frontend/app/src/components/bcgov/BCGovNavBar.vue
@@ -78,7 +78,7 @@ export default {
             data-cy="ManageStatusCode"
             :to="{ name: 'ManageStatusCode' }"
           >
-            Manage Status Code
+            View Record ROWSTATUS Codes
           </router-link>
         </li>
       </ul>

--- a/frontend/app/src/router.js
+++ b/frontend/app/src/router.js
@@ -115,7 +115,7 @@ export default function getRouter(basePath = '/') {
             component: () => import('~/views/setting/ManageStatusCode.vue'),
             meta: {
               accessTo: [RegRoles.REG_ADMIN],
-              breadcrumbTitle: 'Manage Status Code',
+              breadcrumbTitle: 'View Record ROWSTATUS Codes',
               requiresAuth: IdentityProviders.IDIR,
               hasLogin: true,
             },

--- a/frontend/app/src/services/statusService.js
+++ b/frontend/app/src/services/statusService.js
@@ -8,13 +8,13 @@ export default {
   async serviceGetStatusById(id) {
     return appAxios().get(`status/view/${id}`);
   },
-  async serviceAddStatus(data) {
-    return appAxios().post(`status/add`, data);
-  },
-  async serviceUpdateStatus(id, data) {
-    return appAxios().put(`/status/update/${id}`, data);
-  },
-  async serviceDeleteStatusById(id) {
-    return appAxios().delete(`status/delete/${id}`);
-  },
+  // async serviceAddStatus(data) {
+  //   return appAxios().post(`status/add`, data);
+  // },
+  // async serviceUpdateStatus(id, data) {
+  //   return appAxios().put(`/status/update/${id}`, data);
+  // },
+  // async serviceDeleteStatusById(id) {
+  //   return appAxios().delete(`status/delete/${id}`);
+  // },
 };

--- a/frontend/app/src/services/statusService.js
+++ b/frontend/app/src/services/statusService.js
@@ -2,9 +2,6 @@ import { appAxios } from '~/services/interceptors';
 
 export default {
   async serviceGetAllStatus(includeDeleted = false) {
-    return appAxios().get(`status/view/all?isDeleted=` + includeDeleted);
-  },
-  async serviceGetStatusById(id) {
-    return appAxios().get(`status/view/${id}`);
+    return appAxios().get(`statuses?isDeleted=` + includeDeleted);
   },
 };

--- a/frontend/app/src/services/statusService.js
+++ b/frontend/app/src/services/statusService.js
@@ -1,5 +1,4 @@
 import { appAxios } from '~/services/interceptors';
-// import { ApiRoutes } from '~/utils/constants';
 
 export default {
   async serviceGetAllStatus(includeDeleted = false) {
@@ -8,13 +7,4 @@ export default {
   async serviceGetStatusById(id) {
     return appAxios().get(`status/view/${id}`);
   },
-  // async serviceAddStatus(data) {
-  //   return appAxios().post(`status/add`, data);
-  // },
-  // async serviceUpdateStatus(id, data) {
-  //   return appAxios().put(`/status/update/${id}`, data);
-  // },
-  // async serviceDeleteStatusById(id) {
-  //   return appAxios().delete(`status/delete/${id}`);
-  // },
 };

--- a/frontend/app/src/store/statusdata.js
+++ b/frontend/app/src/store/statusdata.js
@@ -10,14 +10,6 @@ export const useStatusDataStore = defineStore('statusdata', {
   }),
   getters: {},
   actions: {
-    async fetchGetStatusById(id) {
-      try {
-        const { data } = await statusService.serviceGetStatusById(id);
-        this.singleStatusData = data;
-      } catch (error) {
-        console.log('Something went wrong. (STOSMDJ#2026)', error); // eslint-disable-line no-console
-      }
-    },
     async fetchGetAllStatus(includeDeleted = false) {
       try {
         const { data } = await statusService.serviceGetAllStatus(

--- a/frontend/app/src/store/statusdata.js
+++ b/frontend/app/src/store/statusdata.js
@@ -10,38 +10,6 @@ export const useStatusDataStore = defineStore('statusdata', {
   }),
   getters: {},
   actions: {
-    // async fetchUpdateStatus(id, payload) {
-    //   try {
-    //     const { data } = await statusService.serviceUpdateStatus(id, payload);
-    //     this.singleStatusData = data;
-    //   } catch (error) {
-    //     console.log('Something went wrong. (STSJHSD#3226)', error); // eslint-disable-line no-console
-    //   }
-    // },
-    // async fetchAddStatus(payload) {
-    //   const notificationStore = useNotificationStore();
-    //   try {
-    //     const { data } = await statusService.serviceAddStatus(payload);
-    //     if (data.statusCode === 200) {
-    //       this.singleStatusData = data.data;
-    //       notificationStore.addNotification({
-    //         text: data.message || 'Status successfully added.',
-    //         type: data.statusCode != 200 ? 'warning' : 'success',
-    //       });
-    //     } else {
-    //       notificationStore.addNotification({
-    //         text: data.message || 'Something went wrong',
-    //         type: data.statusCode != 200 ? 'warning' : 'success',
-    //       });
-    //     }
-    //   } catch (error) {
-    //     notificationStore.addNotification({
-    //       text: error.response.data.message || 'Something went wrong',
-    //       type: error.response.data.status != 200 ? 'error' : 'success',
-    //     });
-    //     console.log('Something went wrong. (STJWSLL#2426)', error); // eslint-disable-line no-console
-    //   }
-    // },
     async fetchGetStatusById(id) {
       try {
         const { data } = await statusService.serviceGetStatusById(id);
@@ -65,55 +33,5 @@ export const useStatusDataStore = defineStore('statusdata', {
         console.log('Something went wrong. (STKSDOD#5965)', error); // eslint-disable-line no-console
       }
     },
-    // async fetchDeleteStatusById(id) {
-    //   const notificationStore = useNotificationStore();
-    //   try {
-    //     const { data } = await statusService.serviceDeleteStatusById(id);
-    //     if (data.statusCode === 200) {
-    //       this.deletedStatusData = data;
-    //       notificationStore.addNotification({
-    //         text: data.message || 'Status deleted successfully.',
-    //         type: data.statusCode === 200 ? 'success' : 'warning',
-    //       });
-    //     } else {
-    //       notificationStore.addNotification({
-    //         text: data.message || 'Something went wrong',
-    //         type: data.statusCode != 200 ? 'warning' : 'success',
-    //       });
-    //     }
-    //   } catch (error) {
-    //     this.deletedStatusData = error.response;
-    //     console.log('Something went wrong. (STLDPWJJ#12655)', error); // eslint-disable-line no-console
-    //     notificationStore.addNotification({
-    //       text: error.response.statusText,
-    //       type: error.response.status != 200 ? 'error' : 'success',
-    //     });
-    //   }
-    // },
-    // async fetchDeleteAllStatus() {
-    //   const notificationStore = useNotificationStore();
-    //   try {
-    //     const { data } = await statusService.serviceDeleteAllStatus();
-
-    //     if (data.statusCode === 200) {
-    //       this.allStatusData = data;
-    //       notificationStore.addNotification({
-    //         text: data.message || 'All Status deleted successfully.',
-    //         type: data.statusCode === 200 ? 'success' : 'warning',
-    //       });
-    //     } else {
-    //       notificationStore.addNotification({
-    //         text: data.message || 'Something went wrong',
-    //         type: data.statusCode != 200 ? 'warning' : 'success',
-    //       });
-    //     }
-    //   } catch (error) {
-    //     console.log('Something went wrong. (STJDWIIK#5698)', error); // eslint-disable-line no-console
-    //     notificationStore.addNotification({
-    //       text: 'Something went wrong',
-    //       type: 'error',
-    //     });
-    //   }
-    // },
   },
 });

--- a/frontend/app/src/store/statusdata.js
+++ b/frontend/app/src/store/statusdata.js
@@ -10,38 +10,38 @@ export const useStatusDataStore = defineStore('statusdata', {
   }),
   getters: {},
   actions: {
-    async fetchUpdateStatus(id, payload) {
-      try {
-        const { data } = await statusService.serviceUpdateStatus(id, payload);
-        this.singleStatusData = data;
-      } catch (error) {
-        console.log('Something went wrong. (STSJHSD#3226)', error); // eslint-disable-line no-console
-      }
-    },
-    async fetchAddStatus(payload) {
-      const notificationStore = useNotificationStore();
-      try {
-        const { data } = await statusService.serviceAddStatus(payload);
-        if (data.statusCode === 200) {
-          this.singleStatusData = data.data;
-          notificationStore.addNotification({
-            text: data.message || 'Status successfully added.',
-            type: data.statusCode != 200 ? 'warning' : 'success',
-          });
-        } else {
-          notificationStore.addNotification({
-            text: data.message || 'Something went wrong',
-            type: data.statusCode != 200 ? 'warning' : 'success',
-          });
-        }
-      } catch (error) {
-        notificationStore.addNotification({
-          text: error.response.data.message || 'Something went wrong',
-          type: error.response.data.status != 200 ? 'error' : 'success',
-        });
-        console.log('Something went wrong. (STJWSLL#2426)', error); // eslint-disable-line no-console
-      }
-    },
+    // async fetchUpdateStatus(id, payload) {
+    //   try {
+    //     const { data } = await statusService.serviceUpdateStatus(id, payload);
+    //     this.singleStatusData = data;
+    //   } catch (error) {
+    //     console.log('Something went wrong. (STSJHSD#3226)', error); // eslint-disable-line no-console
+    //   }
+    // },
+    // async fetchAddStatus(payload) {
+    //   const notificationStore = useNotificationStore();
+    //   try {
+    //     const { data } = await statusService.serviceAddStatus(payload);
+    //     if (data.statusCode === 200) {
+    //       this.singleStatusData = data.data;
+    //       notificationStore.addNotification({
+    //         text: data.message || 'Status successfully added.',
+    //         type: data.statusCode != 200 ? 'warning' : 'success',
+    //       });
+    //     } else {
+    //       notificationStore.addNotification({
+    //         text: data.message || 'Something went wrong',
+    //         type: data.statusCode != 200 ? 'warning' : 'success',
+    //       });
+    //     }
+    //   } catch (error) {
+    //     notificationStore.addNotification({
+    //       text: error.response.data.message || 'Something went wrong',
+    //       type: error.response.data.status != 200 ? 'error' : 'success',
+    //     });
+    //     console.log('Something went wrong. (STJWSLL#2426)', error); // eslint-disable-line no-console
+    //   }
+    // },
     async fetchGetStatusById(id) {
       try {
         const { data } = await statusService.serviceGetStatusById(id);
@@ -65,55 +65,55 @@ export const useStatusDataStore = defineStore('statusdata', {
         console.log('Something went wrong. (STKSDOD#5965)', error); // eslint-disable-line no-console
       }
     },
-    async fetchDeleteStatusById(id) {
-      const notificationStore = useNotificationStore();
-      try {
-        const { data } = await statusService.serviceDeleteStatusById(id);
-        if (data.statusCode === 200) {
-          this.deletedStatusData = data;
-          notificationStore.addNotification({
-            text: data.message || 'Status deleted successfully.',
-            type: data.statusCode === 200 ? 'success' : 'warning',
-          });
-        } else {
-          notificationStore.addNotification({
-            text: data.message || 'Something went wrong',
-            type: data.statusCode != 200 ? 'warning' : 'success',
-          });
-        }
-      } catch (error) {
-        this.deletedStatusData = error.response;
-        console.log('Something went wrong. (STLDPWJJ#12655)', error); // eslint-disable-line no-console
-        notificationStore.addNotification({
-          text: error.response.statusText,
-          type: error.response.status != 200 ? 'error' : 'success',
-        });
-      }
-    },
-    async fetchDeleteAllStatus() {
-      const notificationStore = useNotificationStore();
-      try {
-        const { data } = await statusService.serviceDeleteAllStatus();
+    // async fetchDeleteStatusById(id) {
+    //   const notificationStore = useNotificationStore();
+    //   try {
+    //     const { data } = await statusService.serviceDeleteStatusById(id);
+    //     if (data.statusCode === 200) {
+    //       this.deletedStatusData = data;
+    //       notificationStore.addNotification({
+    //         text: data.message || 'Status deleted successfully.',
+    //         type: data.statusCode === 200 ? 'success' : 'warning',
+    //       });
+    //     } else {
+    //       notificationStore.addNotification({
+    //         text: data.message || 'Something went wrong',
+    //         type: data.statusCode != 200 ? 'warning' : 'success',
+    //       });
+    //     }
+    //   } catch (error) {
+    //     this.deletedStatusData = error.response;
+    //     console.log('Something went wrong. (STLDPWJJ#12655)', error); // eslint-disable-line no-console
+    //     notificationStore.addNotification({
+    //       text: error.response.statusText,
+    //       type: error.response.status != 200 ? 'error' : 'success',
+    //     });
+    //   }
+    // },
+    // async fetchDeleteAllStatus() {
+    //   const notificationStore = useNotificationStore();
+    //   try {
+    //     const { data } = await statusService.serviceDeleteAllStatus();
 
-        if (data.statusCode === 200) {
-          this.allStatusData = data;
-          notificationStore.addNotification({
-            text: data.message || 'All Status deleted successfully.',
-            type: data.statusCode === 200 ? 'success' : 'warning',
-          });
-        } else {
-          notificationStore.addNotification({
-            text: data.message || 'Something went wrong',
-            type: data.statusCode != 200 ? 'warning' : 'success',
-          });
-        }
-      } catch (error) {
-        console.log('Something went wrong. (STJDWIIK#5698)', error); // eslint-disable-line no-console
-        notificationStore.addNotification({
-          text: 'Something went wrong',
-          type: 'error',
-        });
-      }
-    },
+    //     if (data.statusCode === 200) {
+    //       this.allStatusData = data;
+    //       notificationStore.addNotification({
+    //         text: data.message || 'All Status deleted successfully.',
+    //         type: data.statusCode === 200 ? 'success' : 'warning',
+    //       });
+    //     } else {
+    //       notificationStore.addNotification({
+    //         text: data.message || 'Something went wrong',
+    //         type: data.statusCode != 200 ? 'warning' : 'success',
+    //       });
+    //     }
+    //   } catch (error) {
+    //     console.log('Something went wrong. (STJDWIIK#5698)', error); // eslint-disable-line no-console
+    //     notificationStore.addNotification({
+    //       text: 'Something went wrong',
+    //       type: 'error',
+    //     });
+    //   }
+    // },
   },
 });


### PR DESCRIPTION
Work done in this PR:

The PHLAT Tool Main Menu option label 'Manage Status Codes' has been changed to 'View Record ROWSTATUS Codes'.

All / any ROWSTATUS Code screens are view only - remove any functionality for editing and deleting data.

Remove the 'Type' column from the screen.

Data is view only - not editable.