### PR TITLE
Removed two work locations from upload and task management screens

### DIFF
--- a/frontend/app/src/utils/constants.js
+++ b/frontend/app/src/utils/constants.js
@@ -70,8 +70,8 @@ export const RunTypes = Object.freeze({
   loadTypeOFRelationship: 'O-F Relationships',
   loadTypeOORelationship: 'O-O Relationships',
   loadTypeIORelationship: 'I-O Relationships',
-  loadTypeWOXref: 'Wk Location Organization Identifier Cross Reference',
-  loadTypeWPIXref: 'Wk Location Practitioner Identifier Cross Reference',
+  // loadTypeWOXref: 'Wk Location Organization Identifier Cross Reference',
+  // loadTypeWPIXref: 'Wk Location Practitioner Identifier Cross Reference',
 });
 
 /** Status Codes for Control (File Upload) */

--- a/frontend/app/src/utils/constants.js
+++ b/frontend/app/src/utils/constants.js
@@ -70,8 +70,6 @@ export const RunTypes = Object.freeze({
   loadTypeOFRelationship: 'O-F Relationships',
   loadTypeOORelationship: 'O-O Relationships',
   loadTypeIORelationship: 'I-O Relationships',
-  // loadTypeWOXref: 'Wk Location Organization Identifier Cross Reference',
-  // loadTypeWPIXref: 'Wk Location Practitioner Identifier Cross Reference',
 });
 
 /** Status Codes for Control (File Upload) */

--- a/frontend/app/src/views/source-data/TaskManagement.vue
+++ b/frontend/app/src/views/source-data/TaskManagement.vue
@@ -347,12 +347,12 @@ export default {
           <v-chip v-if="item.raw.loadTypeIORelationship" variant="elevated">
             {{ RunTypes.loadTypeIORelationship }}
           </v-chip>
-          <v-chip v-if="item.raw.loadTypeWOXref" variant="elevated">
+          <!-- <v-chip v-if="item.raw.loadTypeWOXref" variant="elevated">
             {{ RunTypes.loadTypeWOXref }}
           </v-chip>
           <v-chip v-if="item.raw.loadTypeWPIXref" variant="elevated">
             {{ RunTypes.loadTypeWPIXref }}
-          </v-chip>
+          </v-chip> -->
         </template>
         <template #item.actions="{ item }">
           <!-- Wait -->

--- a/frontend/app/src/views/source-data/TaskManagement.vue
+++ b/frontend/app/src/views/source-data/TaskManagement.vue
@@ -347,12 +347,6 @@ export default {
           <v-chip v-if="item.raw.loadTypeIORelationship" variant="elevated">
             {{ RunTypes.loadTypeIORelationship }}
           </v-chip>
-          <!-- <v-chip v-if="item.raw.loadTypeWOXref" variant="elevated">
-            {{ RunTypes.loadTypeWOXref }}
-          </v-chip>
-          <v-chip v-if="item.raw.loadTypeWPIXref" variant="elevated">
-            {{ RunTypes.loadTypeWPIXref }}
-          </v-chip> -->
         </template>
         <template #item.actions="{ item }">
           <!-- Wait -->


### PR DESCRIPTION
Removed two work locations from upload and task management screens

> WK Location Organization Identifier Cross Reference

> WK Location Practitioner Identifier Cross Reference

Note: The commented code for those two locations still in the codebase as these locations might be comes up in future.