### PR TITLE
Remove Manage column from status screen

### DIFF
--- a/frontend/app/src/views/setting/ManageStatusCode.vue
+++ b/frontend/app/src/views/setting/ManageStatusCode.vue
@@ -1,41 +1,27 @@
 <script>
-import BaseFilter from '../../components/base/BaseFilter.vue';
 import { mapActions, mapState } from 'pinia';
 import { useStatusDataStore } from '~/store/statusdata';
 import { useAuthStore } from '~/store/auth';
-import { usePreferenceDataStore } from '~/store/displayColumnsPreference';
-import { PerformActions, ViewNames } from '~/utils/constants';
+import { PerformActions } from '~/utils/constants';
 
 export default {
-  components: {
-    BaseFilter,
-  },
   props: {},
   data: () => ({
     loading: true,
     filterData: [],
     search: null,
-    showColumnsDialog: false,
     filterIgnore: [],
     headers: [
       { title: 'Code', key: 'code', removable: true },
       { title: 'Description', key: 'description' },
     ],
-    onlyShowColumns: [],
     dataItems: [],
   }),
 
   computed: {
     ...mapState(useStatusDataStore, ['allStatusData']),
     ...mapState(useAuthStore, ['isRegAdmin', 'isRegUser']),
-    ...mapState(usePreferenceDataStore, ['displayColumnsPreferenceData']),
     PerformActions: () => PerformActions,
-    BASE_FILTER_HEADERS() {
-      let headers = this.BASE_HEADERS.filter(
-        (h) => !this.filterIgnore.some((fd) => fd.key === h.key)
-      );
-      return headers;
-    },
     BASE_HEADERS() {
       let headers = [...this.headers];
 
@@ -45,22 +31,6 @@ export default {
       let headers = this.BASE_HEADERS.filter(
         (h) => !this.filterIgnore.some((fd) => fd.key === h.key)
       );
-      if (this.onlyShowColumns.length) {
-        headers = headers.filter((h) =>
-          this.onlyShowColumns.some((fd) => fd === h.key)
-        );
-      }
-
-      return headers;
-    },
-    PRESELECTED_DATA() {
-      return this.HEADERS.filter(
-        (h) => !this.filterIgnore.some((fd) => fd.key === h.key)
-      );
-    },
-    RESET_HEADERS() {
-      let headers = this.BASE_FILTER_HEADERS;
-
       return headers;
     },
     FILTER_DELETED_DATA() {
@@ -80,10 +50,6 @@ export default {
 
   methods: {
     ...mapActions(useStatusDataStore, ['fetchGetAllStatus']),
-    ...mapActions(usePreferenceDataStore, [
-      'updateUserColumnsDisplayPreference',
-      'fetchUserPreference',
-    ]),
     async populateStatus() {
       // Get the submissions for this form
       await this.fetchGetAllStatus(this.includeDeleted);
@@ -92,43 +58,10 @@ export default {
       });
       this.dataItems = tableRows;
     },
-    async populateHeaders() {
-      // Get the headers from user preferences
-      await this.fetchUserPreference(ViewNames.STATUSCODE);
-      if (this.displayColumnsPreferenceData.length) {
-        this.onlyShowColumns = this.displayColumnsPreferenceData;
-      }
-    },
     initialize() {
       this.loading = true;
-      this.populateHeaders();
       this.populateStatus();
       this.loading = false;
-    },
-    onShowColumnDialog() {
-      this.BASE_FILTER_HEADERS.sort(
-        (a, b) =>
-          this.PRESELECTED_DATA.findIndex((x) => x.title === b.title) -
-          this.PRESELECTED_DATA.findIndex((x) => x.title === a.title)
-      );
-
-      this.showColumnsDialog = true;
-    },
-    async updateFilter(data, changeDisplayColumnsPreference = true) {
-      this.showColumnsDialog = false;
-      this.filterData = data;
-      let preferences = {
-        columns: [],
-      };
-      data.forEach((d) => {
-        preferences.columns.push(d.key);
-      });
-      this.onlyShowColumns = preferences.columns;
-      changeDisplayColumnsPreference &&
-        (await this.updateUserColumnsDisplayPreference(
-          ViewNames.STATUSCODE,
-          preferences.columns
-        ));
     },
     close() {
       this.deleteSingleItem = {};
@@ -169,24 +102,6 @@ export default {
           single-line
         ></v-text-field>
       </div>
-      <div>
-        <span>
-          <v-tooltip location="bottom">
-            <template #activator="{ props }">
-              <v-btn
-                class="mx-1"
-                color="primary"
-                v-bind="props"
-                size="x-small"
-                density="default"
-                icon="mdi:mdi-view-column"
-                @click="onShowColumnDialog"
-              />
-            </template>
-            <span>Manage Columns</span>
-          </v-tooltip>
-        </span>
-      </div>
     </div>
 
     <div>
@@ -203,20 +118,6 @@ export default {
         :search="search"
       >
       </v-data-table>
-
-      <v-dialog v-model="showColumnsDialog" width="700">
-        <BaseFilter
-          input-filter-placeholder="Search Columns"
-          input-save-button-text="Save"
-          :input-data="BASE_FILTER_HEADERS"
-          :preselected-data="PRESELECTED_DATA"
-          :reset-data="RESET_HEADERS"
-          @saving-filter-data="updateFilter"
-          @cancel-filter-data="showColumnsDialog = false"
-        >
-          <template #filter-title><span> Manage Columns </span></template>
-        </BaseFilter>
-      </v-dialog>
     </div>
   </div>
 </template>


### PR DESCRIPTION
This PR contains modifications on the Status screen.
As there are only two columns on the data table now, so we don't need the Manage column feature anymore here.
