### PR TITLE
Added HTTP Strict Transport Security(HSTS) Header

### DIFF
--- a/Infrastructure/static_cloudfront.tf
+++ b/Infrastructure/static_cloudfront.tf
@@ -34,6 +34,11 @@ resource "aws_cloudfront_response_headers_policy" "response_security_headers" {
       override                = true
       content_security_policy = "default-src 'self'; img-src 'self'; font-src 'self' https://fonts.gstatic.com/; connect-src 'self' https://*.hlth.gov.bc.ca/; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com/; script-src 'self' 'unsafe-eval'; base-uri 'self'; form-action 'self'; frame-src 'self' https://*.hlth.gov.bc.ca/"
     }
+
+    strict_transport_security {
+      access_control_max_age_sec = 31536000 // 1 year
+      override = true
+    }
   }
 
   custom_headers_config {


### PR DESCRIPTION
This PR implements the changes to return HSTS header from cloud front. It was reported as security violation. 

It is tested on chrome and Edge latest version available at the time of testing. 

Jira Issue: https://proactionca.ent.cgi.com/jira/browse/BCMOHAD-23702


HSTS header returned by Cloud front in test environment on Edge browser

![image](https://github.com/bcgov/moh-phlat/assets/127803325/b2798fbf-baa2-46a9-9544-afd711a60bd6)


HSTS header returned by Cloud front in test environment on Chrome

![image](https://github.com/bcgov/moh-phlat/assets/127803325/357c6f11-8c3b-48f7-8376-7bb24a687458)

