### PR TITLE
Bcmohad 23994 resolving aws deploy certificate setup

### DIFF
--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -89,8 +89,6 @@ jobs:
           file: backend/app/docker/Dockerfile
           push: true
           tags: ${{ env.DOCKER_TAGS }}
-          build-args: |
-            PLR_TLS_TRUST_CERT=${{ env.PLR_TLS_TRUST_CERT_BASE64_ENCODED }}
 
   terraform_apply:
     name: Terraform Apply

--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -90,7 +90,7 @@ jobs:
           push: true
           tags: ${{ env.DOCKER_TAGS }}
           build-args: |
-            PLR_TLS_TRUST_CERT=${{ env.PLR_TLS_TRUST_CERT_BASE64_ENCODED }}
+            PLR_TLS_TRUST_CERT=${{ secrets.PLR_TLS_TRUST_CERT_BASE64_ENCODED }}
 
   terraform_apply:
     name: Terraform Apply

--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -89,6 +89,8 @@ jobs:
           file: backend/app/docker/Dockerfile
           push: true
           tags: ${{ env.DOCKER_TAGS }}
+          build-args: |
+            PLR_TLS_TRUST_CERT=${{ env.PLR_TLS_TRUST_CERT_BASE64_ENCODED }}
 
   terraform_apply:
     name: Terraform Apply

--- a/backend/app/docker/Dockerfile
+++ b/backend/app/docker/Dockerfile
@@ -21,7 +21,7 @@ COPY src/ ./src/
 COPY ext-libs ./ext-libs
 
 ARG PLR_TLS_TRUST_CERT
-RUN echo "Value of PLR_TLS_TRUST_CERT is: $PLR_TLS_TRUST_CERT"
+#RUN echo "Value of PLR_TLS_TRUST_CERT is: $PLR_TLS_TRUST_CERT"
 #cert is base64 encoded. Decode it before writing to file
 RUN echo $PLR_TLS_TRUST_CERT | base64 -d > ./src/main/resources/plr_tls_trust.cert
 

--- a/backend/app/docker/Dockerfile
+++ b/backend/app/docker/Dockerfile
@@ -21,7 +21,7 @@ COPY src/ ./src/
 COPY ext-libs ./ext-libs
 
 ARG PLR_TLS_TRUST_CERT
-# RUN echo "Value of PLR_TLS_TRUST_CERT is: $PLR_TLS_TRUST_CERT"
+RUN echo "Value of PLR_TLS_TRUST_CERT is: $PLR_TLS_TRUST_CERT"
 #cert is base64 encoded. Decode it before writing to file
 RUN echo $PLR_TLS_TRUST_CERT | base64 -d > ./src/main/resources/plr_tls_trust.cert
 


### PR DESCRIPTION
This release is to apply a fix to aws-deploy.yml that correctly grabs the GitHub certificate base64 encoded secret, which allows the docker build command to properly get and generate the cert file for PLR messaging. No other code changes were needed to resolve this. I have confirmed that this branch works in the Test environment, and the empty View/Edit page displays has also been resolved so it's likely this certificate issue was the culprit behind those issues too.