### PR TITLE
add logs for troubleshooting and optimize health check settings

### DIFF
--- a/Infrastructure/alb.tf
+++ b/Infrastructure/alb.tf
@@ -31,9 +31,9 @@ resource "aws_alb_target_group" "app" {
     interval            = "40"
     protocol            = "HTTP"
     matcher             = "200"
-    timeout             = "10"
+    timeout             = "15"
     path                = var.health_check_path
-    unhealthy_threshold = "2"
+    unhealthy_threshold = "3"
   }
 
   tags = local.common_tags

--- a/Infrastructure/alb.tf
+++ b/Infrastructure/alb.tf
@@ -28,10 +28,10 @@ resource "aws_alb_target_group" "app" {
 
   health_check {
     healthy_threshold   = "3"
-    interval            = "30"
+    interval            = "25"
     protocol            = "HTTP"
     matcher             = "200"
-    timeout             = "15"
+    timeout             = "15" # seconds. should be less than interval
     path                = var.health_check_path
     unhealthy_threshold = "3"
   }

--- a/Infrastructure/alb.tf
+++ b/Infrastructure/alb.tf
@@ -28,7 +28,7 @@ resource "aws_alb_target_group" "app" {
 
   health_check {
     healthy_threshold   = "3"
-    interval            = "40"
+    interval            = "30"
     protocol            = "HTTP"
     matcher             = "200"
     timeout             = "15"

--- a/Infrastructure/fargate.tf
+++ b/Infrastructure/fargate.tf
@@ -110,7 +110,7 @@ resource "aws_ecs_service" "main" {
   cluster                           = aws_ecs_cluster.phlat_cluster.arn
   task_definition                   = aws_ecs_task_definition.phlat_td.arn
   desired_count                     = var.app_count
-  health_check_grace_period_seconds = 30
+  health_check_grace_period_seconds = 90
   wait_for_steady_state             = false
   force_new_deployment              = true
 

--- a/Infrastructure/fargate.tf
+++ b/Infrastructure/fargate.tf
@@ -110,7 +110,7 @@ resource "aws_ecs_service" "main" {
   cluster                           = aws_ecs_cluster.phlat_cluster.arn
   task_definition                   = aws_ecs_task_definition.phlat_td.arn
   desired_count                     = var.app_count
-  health_check_grace_period_seconds = 90
+  health_check_grace_period_seconds = 75 # should be 3 times the ALB health check interval
   wait_for_steady_state             = false
   force_new_deployment              = true
 

--- a/Terraform/prod/terragrunt.hcl
+++ b/Terraform/prod/terragrunt.hcl
@@ -16,5 +16,6 @@ generate "prod_tfvars" {
   api_url = "phlatapi.hlth.gov.bc.ca"
   aurora_acu_min = 0.5
   aurora_acu_max = 3
+  app_count=2
   EOF
 }

--- a/backend/app/src/main/java/com/moh/phlat/backend/advice/ApplicationExceptionHandler.java
+++ b/backend/app/src/main/java/com/moh/phlat/backend/advice/ApplicationExceptionHandler.java
@@ -1,6 +1,9 @@
 package com.moh.phlat.backend.advice;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -10,10 +13,13 @@ import com.moh.phlat.backend.exception.HandleInternalException;
 import com.moh.phlat.backend.exception.HandleNotFoundException;
 
 @RestControllerAdvice
-public class ApplicationExceptionHanler {
+public class ApplicationExceptionHandler {
+    private static final Logger logger = LoggerFactory.getLogger(ApplicationExceptionHandler.class);
+
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public Map<String, String> handleInvalidArgument(MethodArgumentNotValidException ex) {
+        logger.error("Invalid Method Argument", ex);
         Map<String, String> errorMap = new HashMap<>();
         ex.getBindingResult().getFieldErrors().forEach(error -> {
             errorMap.put(error.getField(), error.getDefaultMessage());
@@ -24,6 +30,7 @@ public class ApplicationExceptionHanler {
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(HandleInternalException.class)
     public Map<String, String> handleBusinessException(HandleInternalException ex) {
+        logger.error("Internal error occurred", ex);
         Map<String, String> errorMap = new HashMap<>();
         errorMap.put("Message", ex.getMessage());
         return errorMap;
@@ -32,6 +39,7 @@ public class ApplicationExceptionHanler {
     @ResponseStatus(HttpStatus.NOT_FOUND)
     @ExceptionHandler(HandleNotFoundException.class)
     public Map<String, String> handleBusinessException(HandleNotFoundException ex) {
+        logger.error("Resource not found", ex);
         Map<String, String> errorMap = new HashMap<>();
         errorMap.put("Message", ex.getMessage());
         return errorMap;
@@ -40,6 +48,7 @@ public class ApplicationExceptionHanler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(Exception.class)
     public Map<String, String> handleOtherException(Exception ex) {
+        logger.error("An error occurred", ex);
         Map<String, String> errorMap = new HashMap<>();
         errorMap.put("Message", "The server could not process the request. Please contact customer support");
         return errorMap;


### PR DESCRIPTION
added some logs at in error handler and tweaked the health check intervals.  It appears to be working better now as compared to earlier where the containers were getting deployed 3-4 times before application achieves healthy state.