### PR TITLE
Updated HDS Sub-Type logic to be optional

### DIFF
--- a/backend/app/src/main/java/com/moh/phlat/backend/esb/json/MaintainHdsRequest.java
+++ b/backend/app/src/main/java/com/moh/phlat/backend/esb/json/MaintainHdsRequest.java
@@ -119,11 +119,16 @@ public class MaintainHdsRequest implements PlrRequest {
 	private List<PropertyDto> createPropertyDtos() {
 		List<PropertyDto> propertyList = new ArrayList<>();
 		
-		addHdsProperty(propertyList, processData.getHdsSubType(), "HDS_SUB_TYPE");
+		if (StringUtils.hasText(processData.getHdsSubType())) {
+			addHdsProperty(propertyList, processData.getHdsSubType(), "HDS_SUB_TYPE");
+		}
 		if (StringUtils.hasText(processData.getFacAddressUnit())) {
 			addHdsProperty(propertyList, processData.getFacAddressUnit(), "ADDRESS_UNIT");
 		}
 		
+		if (propertyList.isEmpty()) {
+			return null;
+		}
 		return propertyList;
 	}
 	


### PR DESCRIPTION
PHLAT will now check if there is an HDS Sub-Type first before trying to add it to the request message. Tested successfully in local, ready for a quick review and merge into Main