### PR TITLE
Updates to AddressDoctor certificate password configurations

### DIFF
--- a/Infrastructure/fargate.tf
+++ b/Infrastructure/fargate.tf
@@ -89,6 +89,18 @@ resource "aws_ecs_task_definition" "phlat_td" {
           name      = "ADDRESS_DOCTOR_HOST"
           valueFrom = aws_secretsmanager_secret_version.phlat_address_doctor_host.arn
         },
+        {
+          name      = "ADDRESS_DOCTOR_TRUSTSTORE_PASSWORD"
+          valueFrom = "${aws_secretsmanager_secret_version.phlat_address_doctor_certificates.arn}:truststore_password::"
+        },
+        {
+          name      = "ADDRESS_DOCTOR_KEYSTORE_PASSWORD"
+          valueFrom = "${aws_secretsmanager_secret_version.phlat_address_doctor_certificates.arn}:keystore_password::"
+        },
+        {
+          name      = "ADDRESS_DOCTOR_KEY_PASSWORD"
+          valueFrom = "${aws_secretsmanager_secret_version.phlat_address_doctor_certificates.arn}:key_password::"
+        },
       ]
       environment = [
         {

--- a/Infrastructure/secretsmanager.tf
+++ b/Infrastructure/secretsmanager.tf
@@ -40,6 +40,10 @@ resource "aws_secretsmanager_secret" "phlat_address_doctor_host" {
   name = "${var.application}_address_doctor_host"
 }
 
+resource "aws_secretsmanager_secret" "phlat_address_doctor_certificates" {
+  name = "${var.application}_address_doctor_certificates"
+}
+
 resource "aws_secretsmanager_secret_version" "phlat_db_database" {
   secret_id     = aws_secretsmanager_secret.phlat_db_database.id
   secret_string = "changeme"
@@ -90,6 +94,20 @@ resource "aws_secretsmanager_secret_version" "rds_credentials" {
   "host": "${module.aurora_postgresql_v2.cluster_endpoint}",
   "port": ${module.aurora_postgresql_v2.cluster_port},
   "dbClusterIdentifier": "${module.aurora_postgresql_v2.cluster_id}"
+}
+EOF
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "phlat_address_doctor_certificates" {
+  secret_id     = aws_secretsmanager_secret.phlat_address_doctor_certificates.id
+  secret_string = <<EOF
+{
+  "truststore_password": "changeme",
+  "keystore_password": "changeme",
+  "key_password": "changeme"
 }
 EOF
   lifecycle {

--- a/backend/app/src/main/resources/application.yml
+++ b/backend/app/src/main/resources/application.yml
@@ -64,13 +64,13 @@ spring:
       jks:
         addressdoctor:
           key:
-            password: HCIM
+            password: ${ADDRESS_DOCTOR_KEY_PASSWORD}
           keystore:
             location: classpath:addressdoctor_keystore.jks
-            password: changeit
+            password: ${ADDRESS_DOCTOR_KEYSTORE_PASSWORD}
           truststore:
             location: classpath:addressdoctor_truststore.jks
-            password: changeit
+            password: ${ADDRESS_DOCTOR_TRUSTSTORE_PASSWORD}
 
 # -------------- spring related config ends ---------------------------
 


### PR DESCRIPTION
Moved the passwords for the AddressDoctor key and trust certs into an AWS secret. Made the secret as a propery list, since the passwords are so closely related to each other and unlikely to change