### PR TITLE
Bcmohad 27520 out of memory

### DIFF
--- a/Infrastructure/variables.tf
+++ b/Infrastructure/variables.tf
@@ -19,7 +19,7 @@ variable "fargate_cpu" {
 
 variable "fargate_memory" {
   description = "Fargate instance memory to provision (in MiB)"
-  default     = 1024
+  default     = 2048
 }
 
 variable "phlat_cluster_name" {
@@ -62,7 +62,7 @@ variable "app_image" {
 
 variable "app_count" {
   description = "Number of docker containers to run"
-  default     = 1
+  default     = 2
 }
 
 variable "fam_console_idp_name" {

--- a/Terraform/stag/terragrunt.hcl
+++ b/Terraform/stag/terragrunt.hcl
@@ -8,7 +8,7 @@ generate "stag_tfvars" {
   disable_signature = true
   contents          = <<-EOF
   fargate_cpu = 512
-  fargate_memory = 1024
+  fargate_memory = 2048
   app_port = 8088
   fam_console_idp_name = "PROD-IDIR"
   application = "phlat-stag"

--- a/backend/app/docker/Dockerfile
+++ b/backend/app/docker/Dockerfile
@@ -46,4 +46,4 @@ FROM openjdk:17-jdk
 COPY --from=build app/target/phlat-backend.jar  /app/target/phlat-backend.jar
 
 EXPOSE 8088
-ENTRYPOINT [ "java", "-jar", "/app/target/phlat-backend.jar" ]
+ENTRYPOINT [ "java", "-XX:MaxRAMPercentage=80.0", "-jar", "/app/target/phlat-backend.jar" ]


### PR DESCRIPTION
Three changes for backend application:
1. ECS containers count bumped to two
2. The memory limit for ECS containers is bumped to 2GB
3. New JVM parameter to allow the heap to grow upto 80% of available memory - that one goes to Dockerfile.