### PR TITLE
Switching to full scan the latest for fe and 0.9.0 version for be api…

### DIFF
--- a/.github/workflows/zap-scan.yml
+++ b/.github/workflows/zap-scan.yml
@@ -33,7 +33,7 @@ jobs:
     permissions: write-all
     steps:
       - name: ZAP Frontend Scan
-        uses: zaproxy/action-baseline@v0.9.0
+        uses: zaproxy/action-full-scan@v0.12.0
         with:
           target: ${{ vars.APPLICATION_URL }}
           artifact_name: zap_fe_scan
@@ -45,7 +45,7 @@ jobs:
     permissions: write-all
     steps:
       - name: ZAP API Scan
-        uses: zaproxy/action-api-scan@v0.7.0
+        uses: zaproxy/action-api-scan@v0.9.0
         with:
           target: ${{ vars.VITE_BACKEND_API_URL }}v3/api-docs
           artifact_name: zap_api_scan


### PR DESCRIPTION
ZAP scans started to fail with the following message:
Error: Create Artifact Container failed: The artifact name zap_api_scan is not valid.
It is time to bump the versions of the zap actions. Also I'm replacing the action of zaproxy/action-baseline with zaproxy/action-full-scan
