### PR TITLE
Removing all references to PostgreSQL v13.

### DIFF
--- a/Infrastructure/aurora-v2.tf
+++ b/Infrastructure/aurora-v2.tf
@@ -34,63 +34,9 @@ resource "aws_db_subnet_group" "phlat_subnet_group" {
   }
 }
 
-data "aws_rds_engine_version" "postgresql" {
-  engine  = "aurora-postgresql"
-  version = "13.21"
-}
-
 data "aws_rds_engine_version" "postgresql_15" {
   engine  = "aurora-postgresql"
-  version = "15.10"
-}
-
-module "aurora_postgresql_v2" {
-  source  = "terraform-aws-modules/rds-aurora/aws"
-  version = "7.7.1"
-
-  name              = "${var.phlat_cluster_name}-${var.target_env}"
-  engine            = data.aws_rds_engine_version.postgresql.engine
-  engine_mode       = "provisioned"
-  engine_version    = data.aws_rds_engine_version.postgresql.version
-  storage_encrypted = true
-  database_name     = var.phlat_database_name
-  allow_major_version_upgrade = true
-
-  vpc_id                 = data.aws_vpc.main.id
-  vpc_security_group_ids = [data.aws_security_group.data.id]
-  db_subnet_group_name   = aws_db_subnet_group.phlat_subnet_group.name
-
-  master_username = var.phlat_master_username
-  master_password = random_password.phlat_master_password.result
-
-  create_cluster         = true
-  create_security_group  = false
-  create_db_subnet_group = false
-  create_monitoring_role = false
-  create_random_password = false
-
-  apply_immediately   = true
-  skip_final_snapshot = true
-
-  db_parameter_group_name         = aws_db_parameter_group.phlat_postgresql13.id
-  db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.phlat_postgresql13.id
-
-  serverlessv2_scaling_configuration = {
-    min_capacity = var.aurora_acu_min
-    max_capacity = var.aurora_acu_max
-  }
-
-  instance_class = "db.serverless"
-  instances = {
-    one = {}
-    two = {}
-  }
-
-  tags = {
-    managed-by = "terraform"
-  }
-
-  enabled_cloudwatch_logs_exports = ["postgresql"]
+  version = "15.12"
 }
 
 module "aurora_postgresql_v2_15" {
@@ -140,28 +86,6 @@ module "aurora_postgresql_v2_15" {
   }
 
   enabled_cloudwatch_logs_exports = ["postgresql"]
-}
-
-resource "aws_db_parameter_group" "phlat_postgresql13" {
-  name        = "${var.phlat_cluster_name}-parameter-group"
-  family      = "aurora-postgresql13"
-  description = "${var.phlat_cluster_name}-parameter-group"
-  tags = {
-    managed-by = "terraform"
-  }
-}
-
-resource "aws_rds_cluster_parameter_group" "phlat_postgresql13" {
-  name        = "${var.phlat_cluster_name}-cluster-parameter-group"
-  family      = "aurora-postgresql13"
-  description = "${var.phlat_cluster_name}-cluster-parameter-group"
-  tags = {
-    managed-by = "terraform"
-  }
-  parameter {
-    name  = "timezone"
-    value = var.timezone
-  }
 }
 
 resource "aws_db_parameter_group" "phlat_postgresql15" {

--- a/Infrastructure/secretsmanager.tf
+++ b/Infrastructure/secretsmanager.tf
@@ -90,10 +90,10 @@ resource "aws_secretsmanager_secret_version" "rds_credentials" {
 {
   "username": "phlat",
   "password": "changeme",
-  "engine": "${data.aws_rds_engine_version.postgresql.version}",
-  "host": "${module.aurora_postgresql_v2.cluster_endpoint}",
-  "port": ${module.aurora_postgresql_v2.cluster_port},
-  "dbClusterIdentifier": "${module.aurora_postgresql_v2.cluster_id}"
+  "engine": "${data.aws_rds_engine_version.postgresql_15.version}",
+  "host": "${module.aurora_postgresql_v2_15.cluster_endpoint}",
+  "port": ${module.aurora_postgresql_v2_15.cluster_port},
+  "dbClusterIdentifier": "${module.aurora_postgresql_v2_15.cluster_id}"
 }
 EOF
   lifecycle {


### PR DESCRIPTION
The changes are to remove PostgreSQL 13 cluster from the infrastructure. This branch has been successfully deployed into dev, test and stage and deployment caused the old cluster to be dropped. For prod, we're going to merge these chnage to main and run deployment against main branch.