### PR TITLE
PLR 772 - AD changes to update physical and mailing Addlines

### DIFF
--- a/backend/app/src/main/java/com/moh/phlat/backend/addressdoctor/service/AddressDoctorValidation.java
+++ b/backend/app/src/main/java/com/moh/phlat/backend/addressdoctor/service/AddressDoctorValidation.java
@@ -1,5 +1,7 @@
 package com.moh.phlat.backend.addressdoctor.service;
 
+import com.moh.phlat.backend.service.DbUtilityService;
+import com.moh.phlat.backend.service.RowStatusService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,6 +30,9 @@ import com.moh.phlat.backend.service.MessageSourceSystem;
 
 import lombok.Getter;
 
+import static com.moh.phlat.backend.databc.util.Constants.ADD;
+import static com.moh.phlat.backend.service.DbUtilityService.PHLAT_END_REASON_CODE_CEASE;
+
 @Component
 public class AddressDoctorValidation {
 	
@@ -43,7 +48,7 @@ public class AddressDoctorValidation {
 	}
 	
 	public void validateAddresses(Control control, ProcessData processData) {
-		
+
 		SOAPEnvelopeInput physicalRequest = physicalAddressToAddressDoctorRequest(processData);
 		SOAPEnvelopeOutput physicalResponse = addressDoctorService.validateAddress(control, physicalRequest);
 		processPhysicalAddressResult(physicalResponse, processData);
@@ -51,9 +56,8 @@ public class AddressDoctorValidation {
 		if (StringUtils.hasText(processData.getMailAddr1()) && StringUtils.hasText(processData.getMailCity())) {
 			SOAPEnvelopeInput mailingRequest = mailingAddressToAddressDoctorRequest(processData);
 			SOAPEnvelopeOutput mailingResponse = addressDoctorService.validateAddress(control, mailingRequest);
-			processMailingAddressResult(mailingResponse, processData);
+            processMailingAddressResult(mailingResponse, processData);
 		}
-		
 	}
 	
 	private SOAPEnvelopeInput physicalAddressToAddressDoctorRequest(ProcessData processData) {
@@ -127,155 +131,198 @@ public class AddressDoctorValidation {
 	}
 	
 	private void processPhysicalAddressResult(SOAPEnvelopeOutput addressDoctorResponse, ProcessData processData) {
-		
-		Result result = parseAdressDoctorResult(addressDoctorResponse, processData);
-		if (result == null) {
-			return;
-		}
-		processData.setPhysicalAddrValidationStatus(result.getProcessStatus());
-		
-		if (result.getResultDataSet().getResultData().isEmpty()) {
-			return;
-		}
-		ResultData resultData = result.getResultDataSet().getResultData().get(0);
-		processData.setPhysicalAddrMailabilityScore(resultData.getMailabilityScore());
-		
-		Address address = resultData.getAddress();
-		// Address Lines
-		if (!address.getDeliveryAddressLines().getString().isEmpty()) {
-			processData.setPhysicalAddr1(address.getDeliveryAddressLines().getString().get(0));
-		}
-		if (address.getDeliveryAddressLines().getString().size() > 1) {
-			processData.setPhysicalAddr2(address.getDeliveryAddressLines().getString().get(1));
-		}
-		if (address.getDeliveryAddressLines().getString().size() > 2) {
-			processData.setPhysicalAddr3(address.getDeliveryAddressLines().getString().get(2));
-		}
-		if (address.getDeliveryAddressLines().getString().size() > 3) {
-			processData.setPhysicalAddr4(address.getDeliveryAddressLines().getString().get(3));
-		}
-		// City, Province, Country and PostalCode
-		if (!address.getLocality().getString().isEmpty()) {
-			processData.setPhysicalCity(address.getLocality().getString().get(0));
-		}
-		if (!address.getProvince().getString().isEmpty()) {
-			processData.setPhysicalProvince(address.getProvince().getString().get(0));
-		}
-		if (!address.getCountry().getString().isEmpty()) {
-			processData.setPhysicalCountry(address.getCountry().getString().get(0));
-		}
-		if (!address.getPostalCode().getString().isEmpty()) {
-			processData.setPhysicalPcode(address.getPostalCode().getString().get(0));
-		}
-		// Civic Address
-		if (!address.getHouseNumber().getString().isEmpty()
-				&& !address.getStreet().getString().isEmpty()
-				&& !address.getLocality().getString().isEmpty()
-				&& !address.getProvince().getString().isEmpty()) {
-			String civicAddress = address.getHouseNumber().getString().get(0) + " "
-					+ address.getStreet().getString().get(0) + ", "
-					+ address.getLocality().getString().get(0) + ", "
-					+ address.getProvince().getString().get(0);
-			processData.setFacCivicAddr(civicAddress);
-		}
-		if (!address.getBuilding().getString().isEmpty()) {
-			processData.setFacBuildingName(address.getBuilding().getString().get(0));
-		}
-		if (!address.getSubBuilding().getString().isEmpty()) {
-			processData.setFacAddressUnit(address.getSubBuilding().getString().get(0));
-		}
+
+        Result result = parseAdressDoctorResult(addressDoctorResponse, processData);
+        if (result == null) {
+            return;
+        }
+        processData.setPhysicalAddrValidationStatus(result.getProcessStatus());
+
+        if (result.getResultDataSet().getResultData().isEmpty()) {
+            return;
+        }
+        ResultData resultData = result.getResultDataSet().getResultData().get(0);
+        processData.setPhysicalAddrMailabilityScore(resultData.getMailabilityScore());
+
+        Address address = resultData.getAddress();
+        // Address Lines
+        if (address.getDeliveryAddressLines() == null || address.getDeliveryAddressLines().getString().isEmpty()
+                || address.getDeliveryAddressLines().getString().get(0).isEmpty()) {
+            addError(processData, DbUtilityService.PHLAT_ERROR_CODE, DbUtilityService.PHLAT_ERROR_TYPE,
+                    "Physical address line 1 is mandatory.");
+            logger.info("The AddressDoctor returned null Delivery Address Lines for Physical address.");
+            // Don't update ProcessData Physical-address
+            return;
+        } else {
+            processData.setPhysicalAddr1(address.getDeliveryAddressLines().getString().get(0));
+            // Reset ProcessData Physical address lines and load from AD, if available - based on array size.
+            processData.setPhysicalAddr2("");
+            processData.setPhysicalAddr3("");
+            processData.setPhysicalAddr4("");
+            if (address.getDeliveryAddressLines().getString().size() > 1) {
+                processData.setPhysicalAddr2(address.getDeliveryAddressLines().getString().get(1));
+                if (address.getDeliveryAddressLines().getString().size() > 2) {
+                    processData.setPhysicalAddr3(address.getDeliveryAddressLines().getString().get(2));
+                    if (address.getDeliveryAddressLines().getString().size() > 3) {
+                        processData.setPhysicalAddr4(address.getDeliveryAddressLines().getString().get(3));
+                    }
+                }
+            }
+        }
+        // City, Province, Country and PostalCode
+        if (!address.getLocality().getString().isEmpty()) {
+            processData.setPhysicalCity(address.getLocality().getString().get(0));
+        }
+        if (!address.getProvince().getString().isEmpty()) {
+            processData.setPhysicalProvince(address.getProvince().getString().get(0));
+        }
+        if (!address.getCountry().getString().isEmpty()) {
+            processData.setPhysicalCountry(address.getCountry().getString().get(0));
+        }
+        if (!address.getPostalCode().getString().isEmpty()) {
+            processData.setPhysicalPcode(address.getPostalCode().getString().get(0));
+        }
+        // Civic Address
+        if (!address.getHouseNumber().getString().isEmpty()
+                && !address.getStreet().getString().isEmpty()
+                && !address.getLocality().getString().isEmpty()
+                && !address.getProvince().getString().isEmpty()) {
+            String civicAddress = address.getHouseNumber().getString().get(0) + " "
+                    + address.getStreet().getString().get(0) + ", "
+                    + address.getLocality().getString().get(0) + ", "
+                    + address.getProvince().getString().get(0);
+            processData.setFacCivicAddr(civicAddress);
+        }
+        if (address.getBuilding() != null && !address.getBuilding().getString().isEmpty()) {
+            processData.setFacBuildingName(address.getBuilding().getString().get(0));
+        }
+        if (address.getSubBuilding() != null && !address.getSubBuilding().getString().isEmpty()) {
+            processData.setFacAddressUnit(address.getSubBuilding().getString().get(0));
+        }
 	}
 	
 	private void processMailingAddressResult(SOAPEnvelopeOutput addressDoctorResponse, ProcessData processData) {
-		
-		Result result = parseAdressDoctorResult(addressDoctorResponse, processData);
-		if (result == null) {
-			return;
-		}
-		processData.setMailAddrValidationStatus(result.getProcessStatus());
 
-		if (result.getResultDataSet().getResultData().isEmpty()) {
-			return;
-		}
-		ResultData resultData = result.getResultDataSet().getResultData().get(0);
-		processData.setMailAddrMailabilityScore(resultData.getMailabilityScore());
-		
-		Address address = resultData.getAddress();
-		// Address Lines
-		if (!address.getDeliveryAddressLines().getString().isEmpty()) {
-			processData.setMailAddr1(address.getDeliveryAddressLines().getString().get(0));
-		}
-		if (address.getDeliveryAddressLines().getString().size() > 1) {
-			processData.setMailAddr2(address.getDeliveryAddressLines().getString().get(1));
-		}
-		if (address.getDeliveryAddressLines().getString().size() > 2) {
-			processData.setMailAddr3(address.getDeliveryAddressLines().getString().get(2));
-		}
-		if (address.getDeliveryAddressLines().getString().size() > 3) {
-			processData.setMailAddr4(address.getDeliveryAddressLines().getString().get(3));
-		}
-		// City, Province, Country and PostalCode
-		if (!address.getLocality().getString().isEmpty()) {
-			processData.setMailCity(address.getLocality().getString().get(0));
-		}
-		if (!address.getProvince().getString().isEmpty()) {
-			processData.setMailProvince(address.getProvince().getString().get(0));
-		}
-		if (!address.getCountry().getString().isEmpty()) {
-			processData.setMailCountry(address.getCountry().getString().get(0));
-		}
-		if (!address.getPostalCode().getString().isEmpty()) {
-			processData.setMailPcode(address.getPostalCode().getString().get(0));
-		}
+        Result result = parseAdressDoctorResult(addressDoctorResponse, processData);
+        if (result == null) {
+            return;
+        }
+        processData.setMailAddrValidationStatus(result.getProcessStatus());
+
+        if (result.getResultDataSet().getResultData().isEmpty()) {
+            return;
+        }
+        ResultData resultData = result.getResultDataSet().getResultData().get(0);
+        processData.setMailAddrMailabilityScore(resultData.getMailabilityScore());
+
+        Address address = resultData.getAddress();
+        // Address Lines
+        if (address.getDeliveryAddressLines() == null || address.getDeliveryAddressLines().getString().isEmpty()
+                || address.getDeliveryAddressLines().getString().get(0).isEmpty()) {
+            logger.info("The AddressDoctor returned null Delivery Address Lines for Mailing address.");
+            boolean isUpdate = StringUtils.hasText(processData.getRecordAction()) && !ADD.equals(processData.getRecordAction());
+
+            if (StringUtils.hasText(processData.getMailAddr1()) && StringUtils.hasText(processData.getMailCity())) {
+                if (!isUpdate) {
+                    // CREATE/ADD - Don't create Mailing address - remove ProcessData for Mailing address
+                    processData.setMailAddr1(null);
+                    processData.setMailAddr2(null);
+                    processData.setMailAddr3(null);
+                    processData.setMailAddr4(null);
+                    processData.setMailCity(null);
+                    processData.setMailProvince(null);
+                    processData.setMailCountry(null);
+                    processData.setMailPcode(null);
+
+                } else if (isUpdate && StringUtils.hasText(processData.getMailingAddressGroupAction())) {
+                    // UPDATE - Don't update ProcessData Mailing-address and return;
+                    // Set END_REASON_CODE to CEASE
+                    processData.setMailingAddressGroupAction(PHLAT_END_REASON_CODE_CEASE);
+                }
+            }
+        } else {
+            // Reset ProcessData Mail address lines and load from AD, if available - based on array size.
+            processData.setMailAddr1(address.getDeliveryAddressLines().getString().get(0));
+            processData.setMailAddr2("");
+            processData.setMailAddr3("");
+            processData.setMailAddr4("");
+            if (address.getDeliveryAddressLines().getString().size() > 1) {
+                processData.setMailAddr2(address.getDeliveryAddressLines().getString().get(1));
+                if (address.getDeliveryAddressLines().getString().size() > 2) {
+                    processData.setMailAddr3(address.getDeliveryAddressLines().getString().get(2));
+                    if (address.getDeliveryAddressLines().getString().size() > 3) {
+                        processData.setMailAddr4(address.getDeliveryAddressLines().getString().get(3));
+                    }
+                }
+            }
+
+            // City, Province, Country and PostalCode
+            if (!address.getLocality().getString().isEmpty()) {
+                processData.setMailCity(address.getLocality().getString().get(0));
+            }
+            if (!address.getProvince().getString().isEmpty()) {
+                processData.setMailProvince(address.getProvince().getString().get(0));
+            }
+            if (!address.getCountry().getString().isEmpty()) {
+                processData.setMailCountry(address.getCountry().getString().get(0));
+            }
+            if (!address.getPostalCode().getString().isEmpty()) {
+                processData.setMailPcode(address.getPostalCode().getString().get(0));
+            }
+        }
 	}
 	
 	private Result parseAdressDoctorResult(SOAPEnvelopeOutput addressDoctorResponse, ProcessData processData) {
 		
 		if (addressDoctorResponse == null) {
-			addError(processData, "100", "ERROR", "Could not reach or get a response from the AddressDoctor service");
+			addError(processData,  DbUtilityService.PHLAT_ERROR_CODE, DbUtilityService.PHLAT_ERROR_TYPE,
+                    "Could not reach or get a response from the AddressDoctor service");
 			return null;
 		}
-		
-		SOAPBodyOutput soapBody = addressDoctorResponse.getSoapBody();
-		if (soapBody == null) {
-			logger.error("The SOAP Body message is missing due to a possible PHLAT misconfiguration or an issue with AddressDoctor");
-			addError(processData, "100", "ERROR", "Could not reach or get a response from the AddressDoctor service");
-			return null;
-		} else if (soapBody.getFault() != null) {
-			SOAPFault soapFault = soapBody.getFault();
-			logger.error("SOAPFault error occured attempting to call AddressDoctor\r\nFault Code: {}\r\nFault String: {}", soapFault.getFaultcode(), soapFault.getFaultstring());
-			addError(processData, "100", "ERROR", "The AddressDoctor service could not process the request");
-			return null;
-		}
-		
-		ProcessResponse processResponse = soapBody.getProcessResponse();
-		if (processResponse == null) {
-			logger.error("Could not find the ProcessResponse object due to an unparsable or unexpected AddressDoctor response");
-			addError(processData, "100", "ERROR", "The AddressDoctor service could not process the request");
-			return null;
-		}
-			
-		Response response = processResponse.getProcessResult();
-		if (response.getStatusCode() != 100 && !response.getStatusMessage().equals("OK")) {
-			logger.error("AddressDoctor returned an error response: {} | {}", response.getStatusCode(), response.getStatusMessage());
-			addError(processData, "100", "ERROR", "The AddressDoctor service could not process the request");
-			return null;
+
+        SOAPBodyOutput soapBody = addressDoctorResponse.getSoapBody();
+        if (soapBody == null) {
+            logger.error("The SOAP Body message is missing due to a possible PHLAT misconfiguration or an issue with AddressDoctor");
+            addError(processData, DbUtilityService.PHLAT_ERROR_CODE, DbUtilityService.PHLAT_ERROR_TYPE,
+                    "Could not reach or get a response from the AddressDoctor service");
+            return null;
+        } else if (soapBody.getFault() != null) {
+            SOAPFault soapFault = soapBody.getFault();
+            logger.error("SOAPFault error occured attempting to call AddressDoctor\r\nFault Code: {}\r\nFault String: {}", soapFault.getFaultcode(), soapFault.getFaultstring());
+            addError(processData, DbUtilityService.PHLAT_ERROR_CODE, DbUtilityService.PHLAT_ERROR_TYPE,
+                    "The AddressDoctor service could not process the request");
+            return null;
+        }
+
+        ProcessResponse processResponse = soapBody.getProcessResponse();
+        if (processResponse == null) {
+            logger.error("Could not find the ProcessResponse object due to an unparsable or unexpected AddressDoctor response");
+            addError(processData, DbUtilityService.PHLAT_ERROR_CODE, DbUtilityService.PHLAT_ERROR_TYPE,
+                    "The AddressDoctor service could not process the request");
+            return null;
+        }
+
+        Response response = processResponse.getProcessResult();
+        if (response.getStatusCode() != 100 && !response.getStatusMessage().equals("OK")) {
+            logger.error("AddressDoctor returned an error response: {} | {}", response.getStatusCode(), response.getStatusMessage());
+            addError(processData, DbUtilityService.PHLAT_ERROR_CODE, DbUtilityService.PHLAT_ERROR_TYPE,
+                    "The AddressDoctor service could not process the request");
+            return null;
 		}
 		
 		return response.getResults().getResult().get(0);
 	}
-	
-	private void addError(ProcessData processData, String errorCode, String errorType, String errorMessage) {
-		
-		Message msg = Message.builder()
-				 .messageType(errorType)
-				 .messageCode(errorCode)
-				 .messageDesc(errorMessage)
-				 .sourceSystemName(MessageSourceSystem.PHLAT)
-				 .processData(processData)
-				 .build();
-		processData.getMessages().add(msg);
-		processData.setRowstatusCode("INVALID");
-	}
+
+    private void addError(ProcessData processData, String errorCode, String errorType, String errorMessage) {
+        Message msg = Message.builder()
+                .messageType(errorType)
+                .messageCode(errorCode)
+                .messageDesc(errorMessage)
+                .sourceSystemName(MessageSourceSystem.PHLAT)
+                .processData(processData)
+                .build();
+        processData.getMessages().add(msg);
+        processData.setRowstatusCode(RowStatusService.INVALID);
+    }
 	
 }

--- a/backend/app/src/test/java/com/moh/phlat/backend/addressdoctor/service/AddressDoctorValidationTest.java
+++ b/backend/app/src/test/java/com/moh/phlat/backend/addressdoctor/service/AddressDoctorValidationTest.java
@@ -1,0 +1,351 @@
+package com.moh.phlat.backend.addressdoctor.service;
+
+import com.moh.phlat.backend.addressdoctor.soap.*;
+import com.moh.phlat.backend.model.ProcessData;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.moh.phlat.backend.databc.util.Constants.ADD;
+import static com.moh.phlat.backend.service.DbUtilityService.PHLAT_END_REASON_CODE_CEASE;
+import static com.moh.phlat.backend.service.DbUtilityService.PHLAT_END_REASON_CODE_CHG;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author CGI
+ */
+@ExtendWith(MockitoExtension.class)
+class AddressDoctorValidationTest {
+
+    @InjectMocks
+    private AddressDoctorValidation underTest;
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    @Test
+    public void testValidatePhysicalAddress_withAddrLine2_reformatted() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        SOAPEnvelopeOutput sOAPEnvelopeOutput = createSOAPEnvelopeOutput();
+        ProcessData processData = new ProcessData();
+        processData.setPhysicalAddr1("601 WEST BROADWAY");
+        processData.setPhysicalAddr2("11TH FL");
+        processData.setPhysicalAddr3("");
+        processData.setPhysicalAddr4("");
+        processData.setPhysicalCity("VANCOUVER");
+        processData.setPhysicalProvince("BC");
+        processData.setPhysicalCountry("CANADA");
+        processData.setPhysicalPcode("V5Z 4C2");
+
+        Method method = AddressDoctorValidation.class.getDeclaredMethod("processPhysicalAddressResult", SOAPEnvelopeOutput.class, ProcessData.class);
+        method.setAccessible(true);
+        method.invoke(underTest, sOAPEnvelopeOutput, processData);
+        assertNotNull(processData);
+        assertEquals("601 WEST BROADWAY 11TH FL", processData.getPhysicalAddr1());
+        assertEquals("", processData.getPhysicalAddr2());
+        assertEquals("", processData.getPhysicalAddr3());
+        assertEquals("", processData.getPhysicalAddr4());
+        assertEquals("VANCOUVER", processData.getPhysicalCity());
+        assertEquals("CANADA", processData.getPhysicalCountry());
+        assertEquals("BC", processData.getPhysicalProvince());
+        assertEquals("V5Z 4C2", processData.getPhysicalPcode());
+    }
+
+    @Test
+    public void testValidatePhysicalAddress_ADD_withEmptyADAddressLines_error() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        SOAPEnvelopeOutput sOAPEnvelopeOutput = createSOAPEnvelopeEmptyOutput();
+        ProcessData processData = new ProcessData();
+        processData.setPhysicalAddr1("601 WEST BROADWAY");
+        processData.setPhysicalAddr2("11TH FL");
+        processData.setPhysicalAddr3("");
+        processData.setPhysicalAddr4("");
+        processData.setPhysicalCity("VANCOUVER");
+        processData.setPhysicalProvince("BC");
+        processData.setPhysicalCountry("CANADA");
+        processData.setPhysicalPcode("V5Z 4C2");
+        processData.setMessages(new ArrayList<>());
+        processData.setRecordAction(ADD);
+        processData.setPhysicalAddressGroupAction(PHLAT_END_REASON_CODE_CHG);
+
+        Method method = AddressDoctorValidation.class.getDeclaredMethod("processPhysicalAddressResult", SOAPEnvelopeOutput.class, ProcessData.class);
+        method.setAccessible(true);
+        method.invoke(underTest, sOAPEnvelopeOutput, processData);
+        assertNotNull(processData);
+        assertEquals(1, processData.getMessages().size());
+        assertEquals("ERROR", processData.getMessages().get(0).getMessageType());
+        assertEquals("100", processData.getMessages().get(0).getMessageCode());
+        assertEquals("Physical address line 1 is mandatory.", processData.getMessages().get(0).getMessageDesc());
+    }
+
+    @Test
+    public void testValidatePhysicalAddress_CHG_withEmptyADAddressLines_error() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        SOAPEnvelopeOutput sOAPEnvelopeOutput = createSOAPEnvelopeEmptyOutput();
+        ProcessData processData = new ProcessData();
+        processData.setPhysicalAddr1("601 WEST BROADWAY");
+        processData.setPhysicalAddr2("11TH FL");
+        processData.setPhysicalAddr3("");
+        processData.setPhysicalAddr4("");
+        processData.setPhysicalCity("VANCOUVER");
+        processData.setPhysicalProvince("BC");
+        processData.setPhysicalCountry("CANADA");
+        processData.setPhysicalPcode("V5Z 4C2");
+        processData.setMessages(new ArrayList<>());
+        processData.setRecordAction(PHLAT_END_REASON_CODE_CHG);
+        processData.setPhysicalAddressGroupAction(PHLAT_END_REASON_CODE_CHG);
+
+        Method method = AddressDoctorValidation.class.getDeclaredMethod("processPhysicalAddressResult", SOAPEnvelopeOutput.class, ProcessData.class);
+        method.setAccessible(true);
+        method.invoke(underTest, sOAPEnvelopeOutput, processData);
+        assertNotNull(processData);
+        assertEquals(1, processData.getMessages().size());
+        assertEquals("ERROR", processData.getMessages().get(0).getMessageType());
+        assertEquals("100", processData.getMessages().get(0).getMessageCode());
+        assertEquals("Physical address line 1 is mandatory.", processData.getMessages().get(0).getMessageDesc());
+    }
+
+    @Test
+    public void testValidateMailingAddress_withAddrLine2_reformatted() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        SOAPEnvelopeOutput sOAPEnvelopeOutput = createSOAPEnvelopeOutput();
+        ProcessData processData = new ProcessData();
+        processData.setMailAddr1("601 WEST BROADWAY");
+        processData.setMailAddr2("11TH FL");
+        processData.setMailAddr3("");
+        processData.setMailAddr4("");
+        processData.setMailCity("VANCOUVER");
+        processData.setMailProvince("BC");
+        processData.setMailCountry("CANADA");
+        processData.setMailPcode("V5Z 4C2");
+
+        Method method = AddressDoctorValidation.class.getDeclaredMethod("processMailingAddressResult", SOAPEnvelopeOutput.class, ProcessData.class);
+        method.setAccessible(true);
+        method.invoke(underTest, sOAPEnvelopeOutput, processData);
+        assertNotNull(processData);
+        assertEquals("601 WEST BROADWAY 11TH FL", processData.getMailAddr1());
+        assertEquals("", processData.getMailAddr2());
+        assertEquals("", processData.getMailAddr3());
+        assertEquals("", processData.getMailAddr4());
+        assertEquals("VANCOUVER", processData.getMailCity());
+        assertEquals("CANADA", processData.getMailCountry());
+        assertEquals("BC", processData.getMailProvince());
+        assertEquals("V5Z 4C2", processData.getMailPcode());
+    }
+
+    @Test
+    public void testValidateMailingAddress_ADD_withEmptyADAddressLines() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        SOAPEnvelopeOutput sOAPEnvelopeOutput = createSOAPEnvelopeEmptyOutput();
+        ProcessData processData = new ProcessData();
+        processData.setMailAddr1("601 WEST BROADWAY");
+        processData.setMailAddr2("11TH FL");
+        processData.setMailAddr3("");
+        processData.setMailAddr4("");
+        processData.setMailCity("VANCOUVER");
+        processData.setMailProvince("BC");
+        processData.setMailCountry("CANADA");
+        processData.setMailPcode("V5Z 4C2");
+        processData.setRecordAction(ADD);
+        processData.setMailingAddressGroupAction(PHLAT_END_REASON_CODE_CHG);
+
+        Method method = AddressDoctorValidation.class.getDeclaredMethod("processMailingAddressResult", SOAPEnvelopeOutput.class, ProcessData.class);
+        method.setAccessible(true);
+        method.invoke(underTest, sOAPEnvelopeOutput, processData);
+        assertNotNull(processData);
+        assertNull(processData.getMailAddr1());
+        assertNull(processData.getMailAddr2());
+        assertNull(processData.getMailAddr3());
+        assertNull(processData.getMailAddr4());
+        assertNull(processData.getMailCity());
+        assertNull(processData.getMailCountry());
+        assertNull(processData.getMailProvince());
+        assertNull(processData.getMailPcode());
+        assertEquals(PHLAT_END_REASON_CODE_CHG, processData.getMailingAddressGroupAction());
+        assertEquals(ADD, processData.getRecordAction());
+    }
+
+    @Test
+    public void testValidateMailingAddress_CHG_withEmptyADAddressLines() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        SOAPEnvelopeOutput sOAPEnvelopeOutput = createSOAPEnvelopeEmptyOutput();
+        ProcessData processData = new ProcessData();
+        processData.setMailAddr1("601 WEST BROADWAY");
+        processData.setMailAddr2("11TH FL");
+        processData.setMailAddr3("");
+        processData.setMailAddr4("");
+        processData.setMailCity("VANCOUVER");
+        processData.setMailProvince("BC");
+        processData.setMailCountry("CANADA");
+        processData.setMailPcode("V5Z 4C2");
+        processData.setRecordAction(PHLAT_END_REASON_CODE_CHG);
+        processData.setMailingAddressGroupAction(PHLAT_END_REASON_CODE_CHG);
+
+        Method method = AddressDoctorValidation.class.getDeclaredMethod("processMailingAddressResult", SOAPEnvelopeOutput.class, ProcessData.class);
+        method.setAccessible(true);
+        method.invoke(underTest, sOAPEnvelopeOutput, processData);
+        assertNotNull(processData);
+        assertEquals(PHLAT_END_REASON_CODE_CEASE, processData.getMailingAddressGroupAction());
+        assertEquals(PHLAT_END_REASON_CODE_CHG, processData.getRecordAction());
+        assertEquals("601 WEST BROADWAY", processData.getMailAddr1());
+        assertEquals("11TH FL", processData.getMailAddr2());
+        assertEquals("", processData.getMailAddr3());
+        assertEquals("", processData.getMailAddr4());
+        assertEquals("VANCOUVER", processData.getMailCity());
+        assertEquals("CANADA", processData.getMailCountry());
+        assertEquals("BC", processData.getMailProvince());
+        assertEquals("V5Z 4C2", processData.getMailPcode());
+    }
+
+    private SOAPEnvelopeOutput createSOAPEnvelopeOutput() {
+        SOAPEnvelopeOutput sOAPEnvelopeOutput = new SOAPEnvelopeOutput();
+        SOAPBodyOutput sOAPBodyOutput = new SOAPBodyOutput();
+        ProcessResponse processResponse = new ProcessResponse();
+        Response response = new Response();
+        List<Result> results = new ArrayList<>();
+        Result result = new Result();
+        List<ResultData> resultsData = new ArrayList<>();
+        ResultData resultData = new ResultData();
+        Address address = new Address();
+        List<String> deliveryAddressLines = new ArrayList<>();
+        List<String> country = new ArrayList<>();
+        List<String> locality = new ArrayList<>();
+        List<String> province = new ArrayList<>();
+        List<String> houseNumber = new ArrayList<>();
+        List<String> postalCode = new ArrayList<>();
+        List<String> subBuilding = new ArrayList<>();
+        List<String> street = new ArrayList<>();
+        ArrayOfString deliveryAddressLinesArr = new ArrayOfString();
+        ArrayOfString postalCodeArr = new ArrayOfString();
+        ArrayOfString countryArr = new ArrayOfString();
+        ArrayOfString localityArr = new ArrayOfString();
+        ArrayOfString provinceArr = new ArrayOfString();
+        ArrayOfString houseNumberArr = new ArrayOfString();
+        ArrayOfString subBuildingArr = new ArrayOfString();
+        ArrayOfString streetArr = new ArrayOfString();
+        ArrayOfResult resultsArr = new ArrayOfResult();
+        ArrayOfResultData resultsDataArr = new ArrayOfResultData();
+
+        response.setStatusCode(100);
+        response.setStatusMessage("OK");
+
+        result.setProcessStatus("V2");
+        postalCode.add("V5Z 4C2");
+        ;
+        postalCodeArr.getString().addAll(postalCode);
+        address.setPostalCode(postalCodeArr);
+        street.add("WEST BROADWAY");
+        streetArr.getString().addAll(street);
+        address.setStreet(streetArr);
+        subBuilding.add("11TH FL");
+        subBuildingArr.getString().addAll(subBuilding);
+        address.setSubBuilding(subBuildingArr);
+        houseNumber.add("601");
+        houseNumberArr.getString().addAll(houseNumber);
+        address.setHouseNumber(houseNumberArr);
+        locality.add("VANCOUVER");
+        localityArr.getString().addAll(locality);
+        address.setLocality(localityArr);
+        province.add("BC");
+        provinceArr.getString().addAll(province);
+        address.setProvince(provinceArr);
+        country.add("CANADA");
+        countryArr.getString().addAll(country);
+        address.setCountry(countryArr);
+        deliveryAddressLines.add("601 WEST BROADWAY 11TH FL");
+        deliveryAddressLinesArr.getString().addAll(deliveryAddressLines);
+        address.setDeliveryAddressLines(deliveryAddressLinesArr);
+
+        resultData.setAddress(address);
+        resultsData.add(resultData);
+        resultsDataArr.getResultData().addAll(resultsData);
+        result.setResultDataSet(resultsDataArr);
+        results.add(result);
+        resultsArr.getResult().addAll(results);
+        response.setResults(resultsArr);
+        processResponse.setProcessResult(response);
+        sOAPBodyOutput.setProcessResponse(processResponse);
+        sOAPEnvelopeOutput.setSoapBody(sOAPBodyOutput);
+
+        return sOAPEnvelopeOutput;
+    }
+
+    private SOAPEnvelopeOutput createSOAPEnvelopeEmptyOutput() {
+        SOAPEnvelopeOutput sOAPEnvelopeOutput = new SOAPEnvelopeOutput();
+        SOAPBodyOutput sOAPBodyOutput = new SOAPBodyOutput();
+        ProcessResponse processResponse = new ProcessResponse();
+        Response response = new Response();
+        List<Result> results = new ArrayList<>();
+        Result result = new Result();
+        List<ResultData> resultsData = new ArrayList<>();
+        ResultData resultData = new ResultData();
+        Address address = new Address();
+        List<String> deliveryAddressLines = new ArrayList<>();
+        List<String> country = new ArrayList<>();
+        List<String> locality = new ArrayList<>();
+        List<String> province = new ArrayList<>();
+        List<String> houseNumber = new ArrayList<>();
+        List<String> postalCode = new ArrayList<>();
+        List<String> subBuilding = new ArrayList<>();
+        List<String> street = new ArrayList<>();
+        ArrayOfString deliveryAddressLinesArr = new ArrayOfString();
+        ArrayOfString postalCodeArr = new ArrayOfString();
+        ArrayOfString countryArr = new ArrayOfString();
+        ArrayOfString localityArr = new ArrayOfString();
+        ArrayOfString provinceArr = new ArrayOfString();
+        ArrayOfString houseNumberArr = new ArrayOfString();
+        ArrayOfString subBuildingArr = new ArrayOfString();
+        ArrayOfString streetArr = new ArrayOfString();
+        ArrayOfResult resultsArr = new ArrayOfResult();
+        ArrayOfResultData resultsDataArr = new ArrayOfResultData();
+
+        response.setStatusCode(100);
+        response.setStatusMessage("OK");
+
+        result.setProcessStatus("V2");
+        postalCode.add("V5Z 4C2");
+        ;
+        postalCodeArr.getString().addAll(postalCode);
+        address.setPostalCode(postalCodeArr);
+        street.add("WEST BROADWAY");
+        streetArr.getString().addAll(street);
+        address.setStreet(streetArr);
+        subBuilding.add("11TH FL");
+        subBuildingArr.getString().addAll(subBuilding);
+        address.setSubBuilding(subBuildingArr);
+        houseNumber.add("601");
+        houseNumberArr.getString().addAll(houseNumber);
+        address.setHouseNumber(houseNumberArr);
+        locality.add("VANCOUVER");
+        localityArr.getString().addAll(locality);
+        address.setLocality(localityArr);
+        province.add("BC");
+        provinceArr.getString().addAll(province);
+        address.setProvince(provinceArr);
+        country.add("CANADA");
+        countryArr.getString().addAll(country);
+        address.setCountry(countryArr);
+        deliveryAddressLinesArr.getString().addAll(deliveryAddressLines);
+        address.setDeliveryAddressLines(deliveryAddressLinesArr);
+
+        resultData.setAddress(address);
+        resultsData.add(resultData);
+        resultsDataArr.getResultData().addAll(resultsData);
+        result.setResultDataSet(resultsDataArr);
+        results.add(result);
+        resultsArr.getResult().addAll(results);
+        response.setResults(resultsArr);
+        processResponse.setProcessResult(response);
+        sOAPBodyOutput.setProcessResponse(processResponse);
+        sOAPEnvelopeOutput.setSoapBody(sOAPBodyOutput);
+
+        return sOAPEnvelopeOutput;
+    }
+}


### PR DESCRIPTION
Set AD response to PHLAT. Add error message when AD response for physical address line 1 is null. Modify logic to change data in PHLAT/PLR mailing address for when AD response for mailing address line 1 is null in case for add or chg. Fixes PLR-737 and PLR-642.